### PR TITLE
Status page: Display total number of accounts

### DIFF
--- a/src/app/components/landingRight.ts
+++ b/src/app/components/landingRight.ts
@@ -60,7 +60,13 @@ const landingRight = {
       if (!key) { return '' }
 
       const _key = key.toString()
-      return(`${_key.charAt(0).toUpperCase()}${_key.slice(1)}`)
+      return(`${_key.charAt(0).toUpperCase()}${_key.slice(1).replace(/([A-Z][a-z])/g, ' $1')}`)
+    },
+    formatStatus(entity, status) {
+      if (entity === 'totalAccounts') {
+        return status === -1 ? 'unknown' : status.toString()
+      }
+      return status ? 'Operational' : 'Down'
     },
     trim(text) {
       return String(text).trim()

--- a/src/app/templates/landingRight.html
+++ b/src/app/templates/landingRight.html
@@ -123,7 +123,7 @@
           {{ entity | capitalizeKey }}
         </span>
         <span :class="status ? 'text--green' : 'text--red'" class="text--right">
-          {{ status ? 'Operational' : 'Down' }}
+          {{ entity, status | formatStatus }}
         </span>
       </div>
     </template>

--- a/src/controllers/system.ts
+++ b/src/controllers/system.ts
@@ -4,6 +4,7 @@ import logService from '../services/logger'
 
 // Interfaces
 import { ISystemStatus } from '../interfaces/system'
+import Account from '../models/account'
 
 // Logger setup
 const logger = new logService('System Controller')
@@ -12,11 +13,12 @@ class SystemController {
   public static async getStatus(): Promise<ISystemStatus> {
     try {
       const _dataStoreStatus = await dataStore.ping()
-
+      const _totalAccounts = await Account.getTotalNumber();
       const _status = {
         website: true,
         api: true,
         dataStore: _dataStoreStatus,
+        totalAccounts: _totalAccounts,
       }
 
       logger.info('System status retrieved')
@@ -28,6 +30,7 @@ class SystemController {
         website: true,
         api: true,
         dataStore: false,
+        totalAccounts: -1,
       }
       return _errorStatus
     }

--- a/src/interfaces/system.ts
+++ b/src/interfaces/system.ts
@@ -2,4 +2,5 @@ export interface ISystemStatus {
   website: boolean,
   api: boolean,
   dataStore: boolean,
+  totalAccounts: number,
 }

--- a/src/services/__mocks__/dataStore.ts
+++ b/src/services/__mocks__/dataStore.ts
@@ -3,6 +3,7 @@ const dataStore = {
   set: jest.fn(async () => { return }),
   remove: jest.fn(async () => { return }),
   find: jest.fn(async () => { return }),
+  scan: jest.fn(async () => { return }),
   ping: jest.fn(async () => { return }),
 }
 

--- a/src/services/dataStore.ts
+++ b/src/services/dataStore.ts
@@ -84,10 +84,38 @@ export async function find(pattern: string): Promise<string[]> {
     const _keys = promisify(_redisClient.keys).bind(_redisClient)
     const _storedKeys = await _keys(pattern)
     _redisClient.quit()
-
     return _storedKeys
   } catch (error) {
     logger.error(`Error when finding keys: ${error.message}`)
+    throw new Error('Pantry is having critical issues')
+  }
+}
+
+export async function scan(
+  cursor: number,
+  pattern?: string,
+  count?: number,
+  type?: string,
+): Promise<[string, string[]]> {
+  try {
+    const _args: Array<string | number> = [cursor]
+    if (pattern) {
+      _args.push('MATCH', pattern)
+    }
+    if (count) {
+      _args.push('COUNT', count)
+    }
+    if (type) {
+      _args.push('TYPE', type)
+    }
+
+    const _redisClient = redis.createClient()
+    const _scan = promisify(_redisClient.scan).bind(_redisClient)
+    const _storedKeys = await _scan(..._args)
+    _redisClient.quit()
+    return _storedKeys
+  } catch (error) {
+    logger.error(`Error when scanning: ${error.message}`)
     throw new Error('Pantry is having critical issues')
   }
 }

--- a/tests/controllers/system.test.ts
+++ b/tests/controllers/system.test.ts
@@ -17,6 +17,9 @@ afterEach(() => {
 describe('When fetching system status', () => {
   it ('returns the system status', async () => {
     mockedDataStore.ping.mockReturnValueOnce(Promise.resolve(true))
+    mockedDataStore.scan
+      .mockReturnValueOnce(Promise.resolve(['0', ['account:00000000-0000-0000-0000-000000000000']]))
+      .mockReturnValueOnce(Promise.resolve(['0', ['account:00000000-0000-0000-0000-000000000000']]))
 
     const _status: ISystemStatus = await SystemController.getStatus()
 
@@ -24,6 +27,7 @@ describe('When fetching system status', () => {
       api: true,
       website: true,
       dataStore: true,
+      totalAccounts: 1,
     })
   })
 


### PR DESCRIPTION
Displays the total number of accounts on the status page

This provides transparency about how many people use Pantry (and by extension, gives users an idea of how much time and money goes into maintaining it).

- Adds a static `getTotalNumber()` method to the `Account` class
  - We use the SCAN pattern `account:*-*-*-*-[a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9]` to match 'account:' followed by a UUID, with nothing after it.
- Adds a `totalAccount` field to the `ISystemStatus` interface.
- Adds a `scan()` method to the data store service, which allows use of the Redis command `SCAN`.
- Updates the system controller unit tests to test the above.
- Displays the total number of accounts on the status page.
  - Adds some formatting logic to the frontend to make it look better.

Partially resolves #59