### PR TITLE
Changed to double quotes in npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git"
   },
   "scripts": {
-    "dev": "concurrently -k 'tsc && node dist/src/main.js' 'webpack --config webpack.dev.js'",
+    "dev": "concurrently -k \"tsc && node dist/src/main.js\" \"webpack --config webpack.dev.js\"",
     "dev-server": "tsc && node --inspect=[0.0.0.0] dist/src/main.js",
     "linter": "tslint -c tslint.json -p tsconfig.json",
     "fix-linting": "tslint --fix -p tsconfig.json",


### PR DESCRIPTION
Single quotes don't work on windows, so I changed to double quotes and
escaped them with a backslash (should work on all platforms, tried on
windows and linux).