### PR TITLE
Fix Broken JSON Styling

### DIFF
--- a/src/app/components/landingRight.ts
+++ b/src/app/components/landingRight.ts
@@ -1,6 +1,7 @@
 // External Files
 const axios = require('axios')
 const jsonView = require('vue-json-pretty').default
+import 'vue-json-pretty/lib/styles.css'
 
 // Configs
 const configs = require('../config.ts')


### PR DESCRIPTION
In the dashboard view, the contents of the basket are not being styled properly.
Users should see syntax-enabled formatting to make navigating their basket
contents
easier.

* Import the vue-json-pretty stylesheet

Resolves #108 