### PR TITLE
Allow Users to Edit Pantry Contents via Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14937,10 +14937,13 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
-    "vue-json-pretty": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.6.3.tgz",
-      "integrity": "sha512-dgb04fT9PMndfCI4RiQcqaV5P0hSg97LObm15Mkzjl2hL+qWJd833tOd2RhK/yk8AieZt8eJUac5NTZb31O6Mg=="
+    "vue-json-editor": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/vue-json-editor/-/vue-json-editor-1.4.3.tgz",
+      "integrity": "sha512-st9HdXBgCnyEmmfWrZQiKzp4KuYXzmYVUNDn5h6Fa18MrrGS1amnyUFyv7hQFsNBDW27B7BKkdGOqszYT1srAg==",
+      "requires": {
+        "vue": "^2.2.6"
+      }
     },
     "vue-loader": {
       "version": "15.9.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
     "uuid": "^3.4.0",
     "vue": "^2.5.16",
     "vue-clipboard2": "^0.3.1",
-    "vue-json-pretty": "^1.6.3"
+    "vue-json-editor": "^1.4.3"
   }
 }

--- a/src/app/components/basket.ts
+++ b/src/app/components/basket.ts
@@ -1,0 +1,79 @@
+// External Files
+const axios = require('axios')
+const jsonEditor = require('vue-json-editor').default
+
+// Configs
+const configs = require('../config.ts')
+
+// Templates
+const basketTemplate = require('../templates/basketTemplate.html')
+
+// Constants
+const API_PATH = configs.apiPath
+
+const basket = {
+  props: ['pantry', 'name', 'ttl', 'active'],
+  name: 'basket',
+  components: {
+    'json-edit': jsonEditor,
+  },
+  template: basketTemplate,
+  data(): any {
+    return {
+      apiPath: API_PATH,
+      basket: null,
+    }
+  },
+  methods: {
+    getDateOfDeletion(): string {
+      const _currentDate = new Date()
+      _currentDate.setSeconds(this.ttl)
+      return _currentDate.toISOString().split('T')[0]
+    },
+    toggleBasket(name: string): void {
+      this.$emit('toggle-basket', name)
+    },
+    async load(): Promise<void> {
+      if (this.active) {
+        this.basket = null
+        this.toggleBasket(null)
+      } else {
+        const { data } = await axios({
+          method: 'GET',
+          url: `${API_PATH}/pantry/${this.pantry.id}/basket/${this.name}`,
+        })
+        this.basket = data
+        this.toggleBasket(this.name)
+      }
+    },
+    refreshDashboard(): void {
+      this.$emit('update')
+    },
+    async deleteBasket(): Promise<void> {
+      const _response = confirm(`Are you sure you'd like to delete ${this.name}?`)
+      if (_response) {
+        await axios({
+          method: 'DELETE',
+          url: `${API_PATH}/pantry/${this.pantry.id}/basket/${this.name}`,
+        })
+        this.refreshDashboard()
+      }
+    },
+    async update(): Promise<void> {
+      await axios({
+        method: 'PUT',
+        data: this.basket,
+        url: `${API_PATH}/pantry/${this.pantry.id}/basket/${this.name}`,
+      })
+      alert(`${this.name} contents saved!`)
+      this.refreshDashboard()
+    },
+    copyPath(): void {
+      const _path =  `${API_PATH}/pantry/${this.pantry.id}/basket/${this.name}`
+      this.$emit('copy-basket-path', _path)
+      alert('Basket path copied link to clipboard!')
+    },
+  },
+}
+
+export = basket

--- a/src/app/components/landingRight.ts
+++ b/src/app/components/landingRight.ts
@@ -1,7 +1,5 @@
 // External Files
 const axios = require('axios')
-const jsonView = require('vue-json-pretty').default
-import 'vue-json-pretty/lib/styles.css'
 
 // Configs
 const configs = require('../config.ts')
@@ -11,6 +9,9 @@ const landingRightTemplate = require('../templates/landingRight.html')
 
 // Interfaces
 const { IView } = require('../../interfaces/view.ts')
+
+// Components
+const basket = require('./basket.ts')
 
 /* eslint-disable */ 
 declare global {
@@ -28,7 +29,7 @@ const landingRight = {
   props: ['view'],
   name: 'landingRight',
   components: {
-    'json-view': jsonView,
+    basket,
   },
   template: landingRightTemplate,
   data(): any {
@@ -44,7 +45,6 @@ const landingRight = {
         id: null,
         data: null,
       },
-      basket: null,
       activeBasket: null,
       showErrors: false,
       showNameField: false,
@@ -117,14 +117,8 @@ const landingRight = {
     },
     async toggleBasket(name: string) {
       if (this.activeBasket === name) {
-        this.basket = null
         this.activeBasket = null
       } else {
-        const { data } = await axios({
-          method: 'GET',
-          url: `${API_PATH}/pantry/${this.pantry.id}/basket/${name}`,
-        })
-        this.basket = data
         this.activeBasket = name
       }
     },
@@ -159,10 +153,8 @@ const landingRight = {
       this.$emit('copy-text', this.pantry.id)
       this.copyPantryIdMessage = 'copied!'
     },
-    copyBasketLink(name: string) {
-      const _link =  `${API_PATH}/pantry/${this.pantry.id}/basket/${name}`
-      this.$emit('copy-text', _link)
-      alert('Basket link copied link to clipboard!')
+    copyText(text: string) {
+      this.$emit('copy-text', text)
     },
     beginSignup() {
       this.showNameField = true
@@ -203,10 +195,24 @@ const landingRight = {
 
       return _positiveStatus ? _positiveMessage : _negativeMessage
     },
-    getDateOfDeletion(ttl: number): string {
-      const _currentDate = new Date()
-      _currentDate.setSeconds(ttl)
-      return _currentDate.toISOString().split('T')[0]
+    async refreshDashboard(): Promise<void> {
+      this.fetchPantry(this.pantry.id)
+    },
+    async createNewBasket(): Promise<void> {
+      const _randomNumber = Math.floor((Math.random() * 100) + 1)
+      const _defaultName = `newBasket${_randomNumber}`
+      const _name = prompt('What is the name of the new basket?', _defaultName)
+      if (_name) {
+        await axios({
+          method: 'POST',
+          data: {
+            key: 'value',
+          },
+          url: `${API_PATH}/pantry/${this.pantry.id}/basket/${_name}`,
+        })
+
+        this.fetchPantry(this.pantry.id)
+      }
     },
   },
   mounted() {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,6 +1,6 @@
 // External Files
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faEye, faEyeSlash, faClipboard } from '@fortawesome/free-solid-svg-icons'
+import { faEye, faEyeSlash, faClipboard, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 const vue = require('vue')
 const vueClipboard = require('vue-clipboard2')
@@ -11,6 +11,7 @@ vue.component('font-awesome-icon', FontAwesomeIcon)
 library.add(faClipboard)
 library.add(faEye)
 library.add(faEyeSlash)
+library.add(faTrash)
 
 // CSS
 require('./scss/main.scss')

--- a/src/app/scss/_jsonEditor.scss
+++ b/src/app/scss/_jsonEditor.scss
@@ -1,0 +1,23 @@
+.jsoneditor {
+  border-color: $orange !important;
+
+  &-menu {
+    background-color: $darkOrange !important;
+    border-color: $darkOrange !important;
+    a {
+      display: none;
+    }
+  }
+
+  &-modes {
+    display: none;
+  }
+
+  &-btns {
+    button {
+      background: $primary-color !important;
+      padding: 0.5em 2em !important;
+      color: $white !important;
+    }
+  }
+}

--- a/src/app/scss/_text.scss
+++ b/src/app/scss/_text.scss
@@ -38,6 +38,13 @@ a:any-link {
     background: rgba(255,255,255,0.5);
     color: $text-color;
     overflow-wrap: anywhere;
+
+    &--button {
+      background: $primary-color;
+      color: $white;
+      cursor: pointer;
+      text-align: center;
+    }
   }
   &--code {
     font-family: 'courier', 'sans-serif';

--- a/src/app/scss/main.scss
+++ b/src/app/scss/main.scss
@@ -7,3 +7,4 @@
 @import 'bottomBar';
 @import 'basket';
 @import 'banner';
+@import 'jsonEditor';

--- a/src/app/templates/basketTemplate.html
+++ b/src/app/templates/basketTemplate.html
@@ -1,0 +1,29 @@
+<li class="text__container">
+  {{ this.name }} - 
+  <small>
+    Expiry Date: {{ getDateOfDeletion() }} 
+  </small>
+  <span class="text__button" title="View & Edit Basket Contents" @click="load">
+    <template v-if="active">
+      <font-awesome-icon icon="eye-slash" />
+    </template>
+    <template v-else>
+      <font-awesome-icon icon="eye" />
+    </template>
+  </span>
+  <span class="text__button" title="Delete Basket" @click="deleteBasket">
+    <font-awesome-icon icon="trash" />
+  </span>
+  <span class="text__button" title="Copy Path to Basket" @click="copyPath">
+    <font-awesome-icon icon="clipboard" />
+  </span>
+  <template v-if="active">
+    <div class="basket__payload-container">
+      <json-edit
+        v-model="basket"
+        :mode="'code'"
+        :show-btns="true"
+        @json-save="update" />
+    </div>
+  </template>
+</li> 

--- a/src/app/templates/landingRight.html
+++ b/src/app/templates/landingRight.html
@@ -10,10 +10,17 @@
     </h1>
     <p>
       <template v-if="!showNameField">
-        Focus your efforts on building your next project and leave the
-        data storage to us. We'll help speed up your development time
-        letting you build awesome things fast! Try out our API, and start
-        securely storing data on the cloud for free!
+        <p>
+          Focus your efforts on building your next project and leave the
+          data storage to us. We'll help speed up your development time,
+          letting you build awesome things fast! By using our API, you can start
+          securely storing JSON data on the cloud for free in just 2 minutes.
+        </p>
+        <p>
+          Don't want to use our API? That's ok. We've built a powerful
+          dashboard so you can view and edit your Pantry's contents right from
+          your browser.
+        </p>
       </template>
       <template v-else>
         Let's give your pantry a name! This could be the name of your project
@@ -162,50 +169,40 @@
         <div class="basket__container">
           <ul>
             <template v-for="{ name, ttl } in pantry.data.baskets">
-              <li class="text__container">
-                {{ name }} - 
-                <small>
-                  Expiry Date: {{ getDateOfDeletion(ttl) }} 
-                </small>
-                <span class="text__button" title="View Contents"
-                  @click="toggleBasket(name)">
-                  <template v-if="activeBasket === name">
-                    <font-awesome-icon icon="eye-slash" />
-                  </template>
-                  <template v-else>
-                    <font-awesome-icon icon="eye" />
-                  </template>
-                </span>
-                <span class="text__button" title="Copy Direct Link"
-                  @click="copyBasketLink(name)">
-                  <font-awesome-icon icon="clipboard" />
-                </span>
-                <template v-if="activeBasket === name">
-                  <div class="basket__payload-container">
-                    <json-view
-                      :deep="1"
-                      :showLength="true"
-                      :data="basket"/>
-                  </div>
-                </template>
-              </li> 
+              <basket :pantry="pantry"
+                      :name="name"
+                      :ttl="ttl"
+                      :active="activeBasket === name"
+                      @update="refreshDashboard"
+                      @toggle-basket="toggleBasket"
+                      @copy-basket-path="copyText">
+              </basket>
             </template>
+            <li class="ga-event-create-basket-lazy text__container text__container--button"
+                @click="createNewBasket">
+              Create New Basket
+            </li> 
           </ul>
         </div>
       </template>
       <template v-else>
         <p>
-          To add a basket to your pantry, simply send a <b>POST</b> request
+          The Pantry API is organized around
+          <a href="https://en.wikipedia.org/wiki/Representational_state_transfer">REST</a>.
+          To get started, add a basket to your pantry by sending a <b>POST</b> request
           to our API with the <b>name</b> and the <b>payload</b> of the basket.
+        </p>
+        <p>
+          Or, if you're familiar with using the terminal, paste a snippet from
+          below to create your first basket, titled "testBasket"
         </p>
         <button @click="showDocs">
           Show Me The API Docs!
         </button>
-        <p>
-          If you're familiar with using the terminal, paste the snippet from
-          below to create your first basket, titled "testBasket"
-        </p>
-        <h2>Linux</h2>
+        <button class="ga-event-create-basket" @click="createNewBasket">
+          I'm lazy, create a basket now!
+        </button>
+        <h2>Unix/Linux - Curl</h2>
         <p class="text__container text--code">
           curl -XPOST -H "Content-type: application/json" -d '{
             "key": "value"
@@ -222,12 +219,13 @@
     <template v-else>
       <h1>View Your Pantry</h1>
       <p>
-        Don't want to use our API? It's ok, we've all been there.
-        Enter your PantryID below and we'll show you what's inside it! 
+        Enter your PantryID below and we'll show you what's inside it. You'll
+        also be able to create new baskets, edit their JSON content and delete
+        existing baskets.
       </p>
       <div class="input__container">
         <input v-model="pantry.id" placeholder="Please paste your PantryID">
-        <button @click="loadPantry" :disabled="!pantryIDValid()">
+        <button class="ga-event-dashboard-login" @click="loadPantry" :disabled="!pantryIDValid()">
           Explore
         </button>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8495,10 +8495,12 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-json-pretty@^1.6.3:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-1.8.1.tgz#538bb57fc718544152105aef659b4c88475365ee"
-  integrity sha512-GHi8q6QLx8fw8XDhAgztlC6emupptpmV5a+yd4UxteEoPqGHXwpgscTbTTxwH2GEdmYXHAt+GLg5tAsenLZKDA==
+vue-json-editor@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/vue-json-editor/-/vue-json-editor-1.4.3.tgz#004c9037ac91f16dd8fc558c9914e5f33a41d71c"
+  integrity sha512-st9HdXBgCnyEmmfWrZQiKzp4KuYXzmYVUNDn5h6Fa18MrrGS1amnyUFyv7hQFsNBDW27B7BKkdGOqszYT1srAg==
+  dependencies:
+    vue "^2.2.6"
 
 vue-loader@^15.9.2:
   version "15.9.8"
@@ -8539,7 +8541,7 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.5.16:
+vue@^2.2.6, vue@^2.5.16:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==


### PR DESCRIPTION
<img width="665" alt="Screen Shot 2021-09-27 at 4 50 11 PM" src="https://user-images.githubusercontent.com/3347296/135089451-4f38c945-59c3-41cf-aebe-4377284b318f.png">
The dashboard as it stands now is very much a read-only application.
We should allow users who do not want to use the API to be able to manipulate
their pantry contents (baskets) via the dashboard. Users should be able to add,
remove and edit existing baskets via some form of JSON editor.

* Replace json-pretty with json-editor
* Abstracted backet logic to a new vue component
* Add ability to delete baskets
* Add ability to create new baskets
* Changed copy to reflect new features

Resolves #112