### PR TITLE
Increase BodyParser Request Limit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ const logger = new logService('API')
 
 // Express server setup and start
 app.use(cors())
-app.use(bodyParser.json())
+app.use(bodyParser.json({ limit: '1mb' }))
 app.use(express.static(__dirname))
 app.use(helmet())
 


### PR DESCRIPTION
The default limit per request is 100kb. Users should be able to post more data
into their baskets, so increasing the default to 1mb should be sufficient.

This change addresses the need by:
- Increasing the BodyParser limit to 1mb

Resolves #117