### PR TITLE
Add Unity Client to list of SDK's

### DIFF
--- a/src/app/components/sdk.ts
+++ b/src/app/components/sdk.ts
@@ -91,6 +91,13 @@ const sdk = {
           link: 'https://github.com/Atoo35/pantry_client_rust/',
           verified: false,
         },
+        {
+          name: 'UniPantry',
+          platform: 'Unity',
+          author: 'Dmitry Koleev',
+          link: 'https://github.com/dkoleev/UniPantry/',
+          verified: false,
+        },
       ],
       defaultBadgeClasses: `flex-shrink-0 inline-block px-2 py-0.5
                             text-xs font-medium


### PR DESCRIPTION
Pantry [client](https://github.com/dkoleev/UniPantry) for Unity Game Engine.

Updated sdk component to add Unity client details