### PR TITLE
Added Common Lisp client library link

### DIFF
--- a/src/app/components/sdk.ts
+++ b/src/app/components/sdk.ts
@@ -98,6 +98,13 @@ const sdk = {
           link: 'https://github.com/dkoleev/UniPantry/',
           verified: false,
         },
+        {
+          name: 'pantry',
+          platform: 'Common Lisp',
+          author: 'Aleksandar Simić',
+          link: 'https://github.com/dotemacs/pantry/',
+          verified: false,
+        },
       ],
       defaultBadgeClasses: `flex-shrink-0 inline-block px-2 py-0.5
                             text-xs font-medium


### PR DESCRIPTION
Added Common Lisp client library for Pantry:

https://github.com/dotemacs/pantry

The project has been submitted to [Quicklisp](https://www.quicklisp.org/beta/) for featuring in the next release: https://github.com/quicklisp/quicklisp-projects/issues/2500

And it's already featured in Ultralisp: https://ultralisp.org/projects/dotemacs/pantry
